### PR TITLE
update home page max width to match other pages and header

### DIFF
--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -20,7 +20,7 @@ export default function Home() {
   }
 
   return (
-    <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
+    <Container maxWidth="lg" sx={{ mt: 4, mb: 4 }}>
       <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
         <Button variant={status === 'incomplete' ? 'contained' : 'outlined'} onClick={() => setStatus('incomplete')}>
           Active


### PR DESCRIPTION
Fixes this width discrepancy on the home page:

<img width="1567" height="447" alt="image" src="https://github.com/user-attachments/assets/fd0533a4-fb7b-485c-b97d-c7fe6849db17" />
